### PR TITLE
Update Kickbox to 3.0.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "kickbox.io"
     ],
     "require": {
-        "kickbox/kickbox": "2.2.5"
+        "kickbox/kickbox": "^3.0.0"
     },
     "type": "magento2-module",
     "authors": [


### PR DESCRIPTION
Fixes https://github.com/linusshops/storefront/issues/10.

Since this is a wrapper around Kickbox we need to upgrade the underlying Kickbox package so it's Guzzle's version matches Magento's. See v3.0.0 - https://github.com/kickboxio/kickbox-php/blob/v3.0.0/composer.json

Highlight of changes in this PR:

- Update Kickbox to 3.0.0